### PR TITLE
Update BF905_self_opening

### DIFF
--- a/BF905_self_opening
+++ b/BF905_self_opening
@@ -1,27 +1,29 @@
-<!-- This script modifies the behavior of the BF905 popup with messenger buttons: it ads ease-in animation for the button 
-and opens the popuf after 35 seconds after loading the page. Don't forget to change the block ID for new implementations
+<!-- This script modifies the behavior of the BF905 popup with messenger buttons: it adds ease-in animation for the button 
+and opens the popup after 35 seconds after loading the page, but only if it isn't already open.
 (c) @m_ppv (telegram) -->
 
 <script>
-
-    document.addEventListener('DOMContentLoaded', function() {
-      var popupTrigger = document.querySelector('#rec907453726 .t825__btn button');
-      
-      if (popupTrigger) {
-        // Initially hide the button by setting its opacity to 0 and defining a transition effect
-        popupTrigger.style.opacity = 0;
-        popupTrigger.style.transition = 'opacity 1s ease-in';
+  document.addEventListener('DOMContentLoaded', function() {
+    var popupTrigger = document.querySelector('#rec907453726 .t825__btn button');
+    var popupContainer = document.querySelector('#rec907453726 .t825__popup');
     
-        // After 5 seconds, fade the button in by setting its opacity to 1
-        setTimeout(function() {
-          popupTrigger.style.opacity = 1;
-        }, 5000);
-    
-        // After 35 seconds, simulate a click on the button to open the popup
-        setTimeout(function() {
+    if (popupTrigger) {
+      // Initially hide the button by setting its opacity to 0 and defining a transition effect
+      popupTrigger.style.opacity = 0;
+      popupTrigger.style.transition = 'opacity 1s ease-in';
+  
+      // After 5 seconds, fade the button in by setting its opacity to 1
+      setTimeout(function() {
+        popupTrigger.style.opacity = 1;
+      }, 5000);
+  
+      // After 35 seconds, simulate a click on the button to open the popup
+      // Only perform the click if the popup container is not already visible (i.e. its display is "none")
+      setTimeout(function() {
+        if (popupContainer && window.getComputedStyle(popupContainer).display === "none") {
           popupTrigger.click();
-        }, 35000);
-      }
-    });
-    
+        }
+      }, 35000);
+    }
+  });
 </script>


### PR DESCRIPTION
In this version, we first query for the popup container element and then check its computed style (assuming the popup is hidden using CSS display property). The click on the trigger button is simulated only if the popup is not already open